### PR TITLE
reboot function cannot have the same name

### DIFF
--- a/gluon-quickfix/files/lib/gluon/quickfix/quickfix.sh
+++ b/gluon-quickfix/files/lib/gluon/quickfix/quickfix.sh
@@ -40,17 +40,17 @@ done
 # reboots #
 ###########
 
-reboot() {
+rb() {
 	logger -s -t "gluon-quickfix" -p 5 "rebooting... reason: $@"
 	# push log to server here (nyi)
 	/sbin/reboot # comment out for debugging purposes
 }
 
 # if respondd or dropbear not running, reboot (probably ram was full, so more services might've crashed)
-pgrep respondd >/dev/null || reboot "respondd not running"
-pgrep dropbear >/dev/null || reboot "dropbear not running"
+pgrep respondd >/dev/null || rb "respondd not running"
+pgrep dropbear >/dev/null || rb "dropbear not running"
 
 # reboot if there was a kernel (batman) error
 # for an example gluon issue #680
-dmesg | grep "Kernel bug" >/dev/null && reboot "gluon issue #680"
+dmesg | grep "Kernel bug" >/dev/null && rb "gluon issue #680"
 


### PR DESCRIPTION
`reboot` without path already reboots the router, the function would be never called, so no debugging would be possible there