### PR TITLE
gluon-ssid-changer: fix for batctl 2016.4+

### DIFF
--- a/gluon-ssid-changer/files/lib/gluon/ssid-changer/ssid-changer.sh
+++ b/gluon-ssid-changer/files/lib/gluon/ssid-changer/ssid-changer.sh
@@ -21,7 +21,7 @@ else
 fi
 
 #Is there an active Gateway?
-GATEWAY_TQ=`batctl gwl | grep "^=>" | awk -F'[()]' '{print $2}'| tr -d " "` #Grep the Connection Quality of the Gateway which is currently used
+GATEWAY_TQ=`batctl gwl | grep -e "^=>" -e "^\*" | awk -F'[()]' '{print $2}'| tr -d " "` #Grep the Connection Quality of the Gateway which is currently used
 
 if [ ! $GATEWAY_TQ ]; #If there is no gateway there will be errors in the following if clauses
 then


### PR DESCRIPTION
this adjusts the grep for gateways so that it also works after updating to batctl 2016.4