### PR TITLE
don't reboot during the first hour

### DIFF
--- a/gluon-wificheck/files/lib/gluon/wificheck/wificheck.sh
+++ b/gluon-wificheck/files/lib/gluon/wificheck/wificheck.sh
@@ -21,7 +21,8 @@ if [ -z "$mname" ] ; then
         if [ -f /tmp/wifipbflag2 ] ; then
           logger -s -t "gluon-wificheck" -p 5 "2nd time no wifi neighbours, rebooting!"
           sleep 3
-          reboot -f
+          # don't reboot during the first hour
+          [ $(cat /proc/uptime | sed 's/\..*//g') -gt 3600 ] || reboot -f
          else
           logger -s -t "gluon-wificheck" -p 5 "still no wifi neighbours."
           echo 1>/tmp/wifipbflag2


### PR DESCRIPTION
it makes no sense to reboot during the first one hour, but this could happen, for example, in an installation session, where you install several routers in a room and switch lots of them off at the same time.

Even if a router gets the wifi-bug during the first few minutes already, you don't want to reboot it immediately. this can make it complicated to debug the scenario.