### PR TITLE
exclude any eth interface

### DIFF
--- a/eulenfunk-hotfix/files/lib/gluon/eulenfunk-hotfix/IfNoWificlient.sh
+++ b/eulenfunk-hotfix/files/lib/gluon/eulenfunk-hotfix/IfNoWificlient.sh
@@ -3,7 +3,7 @@ upgrade_started='/tmp/autoupdate.lock'
 
 [ -f $upgrade_started ] && exit
 
-cliifs=$(/usr/sbin/brctl show | sed -n -e '/^br-client[[:space:]]/,/^\S/ { /^\(br-client[[:space:]]\|\t\)/s/^.*\t//p }' | grep -v "bat0\|eth" | grep -v "local-port"| tr '\n' ' ')
+cliifs=$(/usr/sbin/brctl show | sed -n -e '/^br-client[[:space:]]/,/^\S/ { /^\(br-client[[:space:]]\|\t\)/s/^.*\t//p }' | grep -v "bat0\|eth\|local-port"| tr '\n' ' ')
 
 APoff=1
 for r in 0 1 2; do

--- a/eulenfunk-hotfix/files/lib/gluon/eulenfunk-hotfix/IfNoWificlient.sh
+++ b/eulenfunk-hotfix/files/lib/gluon/eulenfunk-hotfix/IfNoWificlient.sh
@@ -3,7 +3,7 @@ upgrade_started='/tmp/autoupdate.lock'
 
 [ -f $upgrade_started ] && exit
 
-cliifs=$(/usr/sbin/brctl show | sed -n -e '/^br-client[[:space:]]/,/^\S/ { /^\(br-client[[:space:]]\|\t\)/s/^.*\t//p }' | grep -v "bat0" | grep -v "local-port"| tr '\n' ' ')
+cliifs=$(/usr/sbin/brctl show | sed -n -e '/^br-client[[:space:]]/,/^\S/ { /^\(br-client[[:space:]]\|\t\)/s/^.*\t//p }' | grep -v "bat0\|eth" | grep -v "local-port"| tr '\n' ' ')
 
 APoff=1
 for r in 0 1 2; do


### PR DESCRIPTION
This should exclude all wired interfaces, to prevent the reboot of nodes without a wifi client interface. This should solve #32