### PR TITLE
[eulenfunk-hotfix] bugfixes

### DIFF
--- a/eulenfunk-hotfix/Makefile
+++ b/eulenfunk-hotfix/Makefile
@@ -27,7 +27,6 @@ endef
 define Package/$(PKG_NAME)/install
 	$(CP) ./files/* $(1)/
 	./gluonShellDiet.sh $(1)/lib/gluon/eulenfunk-hotfix/rebootIfNoGw.sh 
-	./gluonShellDiet.sh $(1)/lib/gluon/eulenfunk-hotfix/rebootIfNoGw.sh
 	./gluonShellDiet.sh $(1)/lib/gluon/eulenfunk-hotfix/healthcheck.sh
 	./gluonShellDiet.sh $(1)/lib/gluon/eulenfunk-hotfix/check_hostapd.sh
 endef

--- a/eulenfunk-hotfix/files/lib/gluon/eulenfunk-hotfix/IfNoWificlient.sh
+++ b/eulenfunk-hotfix/files/lib/gluon/eulenfunk-hotfix/IfNoWificlient.sh
@@ -3,7 +3,7 @@ upgrade_started='/tmp/autoupdate.lock'
 
 [ -f $upgrade_started ] && exit
 
-cliifs=$(/usr/sbin/brctl show | sed -n -e '/^br-client[[:space:]]/,/^\S/ { /^\(br-client[[:space:]]\|\t\)/s/^.*\t//p }' | grep -v "bat0" | grep -v "local-port"| tr '\n' ' ')
+cliifs=$(/usr/sbin/brctl show | sed -n -e '/^br-client[[:space:]]/,/^\S/ { /^\(br-client[[:space:]]\|\t\)/s/^.*\t//p }' | grep -v "bat0\|eth\|local-port"| tr '\n' ' ')
 
 APoff=1
 for r in 0 1 2; do

--- a/eulenfunk-hotfix/files/lib/gluon/eulenfunk-hotfix/healthcheck.sh
+++ b/eulenfunk-hotfix/files/lib/gluon/eulenfunk-hotfix/healthcheck.sh
@@ -14,7 +14,7 @@ now_reboot() {
   # second optional -f to force reboot even if autoupdater is running
   logger -s -t "eulenfunk-healthcheck" -p 5 "rebooting... reason: $1"
   if [ "$(sed 's/\..*//g' /proc/uptime)" -gt "3600" ] ; then
-    LOG=/lib/gluon/healthcheck/reboot.log
+    LOG=/lib/gluon/eulenfunk-hotfix/reboot.log
     # the first 5 times log the reason for a reboot in a file that is rebootsave
     [ "$(wc -l < $LOG)" -gt 5 ] || echo "$(date) $1" >> $LOG
     if [ "$2" != "-f" ] && [ -f /tmp/autoupdate.lock ] ; then


### PR DESCRIPTION
These bugfixes have been used in ffac since a few years on these packages but have not been contributed upstream.

- fix log path of reboots from eulenfunk-hotfix
- don't copy rebootIfNoGw.sh script twice
- eth devices are never radio devices and should not be considered as such (even though this doesn't harm in this script either)